### PR TITLE
docs: fix expected.xml golden case count in parity-roadmap.md (66 → 44)

### DIFF
--- a/docs/parity-roadmap.md
+++ b/docs/parity-roadmap.md
@@ -167,7 +167,7 @@ CLI엔 연결 안 됨.
 JSON 출력과 1:1. Empty-text drop 규칙도 JSON과 동일.
 
 구현: `Report::to_xml_string(option)`, `ViolationRecord::append_xml`.
-Golden: 각 케이스당 `expected.xml` 커밋됨 (66개).
+Golden: 각 케이스당 `expected.xml` 커밋됨 (44개).
 
 ---
 


### PR DESCRIPTION
## Summary

`docs/parity-roadmap.md` states "Golden: 각 케이스당 `expected.xml` 커밋됨 (66개)" but there are 44 golden cases, so there are 44 `expected.xml` files.

Verified:
```
$ ls testdata/golden/ | grep -E '^[0-9]+' | wc -l
44
```

The number 66 appears to be a stale value from an earlier draft.