### PR TITLE
docs: correct JID registry entry count (217 → 218)

### DIFF
--- a/docs/jid-registry.md
+++ b/docs/jid-registry.md
@@ -4,7 +4,7 @@
 
 `crates/polaris-dvc-core/src/jid_registry.rs` holds a `pub const JID_*:
 ErrorCode` declaration for every `#define JID_*` in upstream
-`third_party/dvc-upstream/Source/JsonModel.h` — 217 entries at the time
+`third_party/dvc-upstream/Source/JsonModel.h` — 218 entries at the time
 this was written.
 
 The curated `jid` submodule in `crates/polaris-dvc-core/src/error_codes.rs`
@@ -53,7 +53,7 @@ that check temporarily, set `POLARIS_ALLOW_JID_DRIFT=1`.
 
 ## Coverage status
 
-The full 217-entry registry is available as Rust constants. The engine
+The full 218-entry registry is available as Rust constants. The engine
 currently references ~30 of them through the curated aliases; the rest
 are declared so downstream work (additional table fields, border-fill
 rules on CharPr, outline-shape specifics, etc.) can reference them

--- a/docs/parity-roadmap.md
+++ b/docs/parity-roadmap.md
@@ -1,7 +1,7 @@
 # DVC 기능 Parity 로드맵
 
 현재 polaris는 업스트림 `sample/test.json`이 쓰는 10개 카테고리 전부를
-커버하고 있고, `JsonModel.h`의 217개 JID 전부를 `jid_registry.rs`에
+커버하고 있고, `JsonModel.h`의 218개 JID 전부를 `jid_registry.rs`에
 상수로 매핑해 두었다. 진짜 "DVC parity"라고 부르려면 남은 것들이 있다.
 
 ## Parity 전략: Dual-mode (`CheckProfile`)


### PR DESCRIPTION
## Summary

Three places in the docs state the JID registry contains 217 entries, but the actual count is 218.

Verified:
```
$ grep -c 'JID_' crates/polaris-dvc-core/src/jid_registry.rs
218
```

## Files changed

- `docs/jid-registry.md` — two occurrences (introduction paragraph and coverage status section)
- `docs/parity-roadmap.md` — one occurrence