### PR TITLE
docs: fix upstream binary name in golden-tests.md

### DIFF
--- a/docs/golden-tests.md
+++ b/docs/golden-tests.md
@@ -45,7 +45,7 @@ that polaris matches DVC bit-for-bit on a given fixture, use a Windows
 (or Wine) environment:
 
 ```cmd
-DVCModel.exe -j --file=actual.json -t testdata\golden\02_fontsize_mismatch\spec.json testdata\golden\02_fontsize_mismatch\doc.hwpx
+ExampleWindows.exe -j --file=actual.json -t testdata\golden\02_fontsize_mismatch\spec.json testdata\golden\02_fontsize_mismatch\doc.hwpx
 diff actual.json testdata\golden\02_fontsize_mismatch\expected.json
 ```
 


### PR DESCRIPTION
The parity verification example command referenced `DVCModel.exe` but the actual upstream binary is `ExampleWindows.exe`. Updated to match the real binary name.