### PR TITLE
docs: document expected.xml in golden-tests.md

### DIFF
--- a/docs/golden-tests.md
+++ b/docs/golden-tests.md
@@ -8,11 +8,12 @@ directory contains three committed files:
 | `doc.hwpx` | realistic HWPX document, produced from a Rust template |
 | `spec.json` | the DVC rule file applied during the run |
 | `expected.json` | the DVC-shaped JSON array the engine must emit under `OutputOption::AllOption` |
+| `expected.xml` | the same violations serialised as XML (Extended profile only) |
 
 `crates/polaris-dvc-core/tests/golden.rs` iterates every case on every test
 run. A case fails if either the freshly-built `doc.hwpx` bytes drift from
 the committed file, or if the engine output diverges from
-`expected.json`.
+`expected.json` or `expected.xml`.
 
 ## Running
 
@@ -33,9 +34,9 @@ cargo test -p polaris-dvc-core --test golden
    ```sh
    POLARIS_REGEN_FIXTURES=1 cargo test -p polaris-dvc-core --test golden
    ```
-   This rewrites `doc.hwpx`, `spec.json`, and `expected.json` for every
-   case. Review the diff before committing.
-5. Commit the updated test code and the three files for each affected
+   This rewrites `doc.hwpx`, `spec.json`, `expected.json`, and
+   `expected.xml` for every case. Review the diff before committing.
+5. Commit the updated test code and the four files for each affected
    case.
 
 ## Parity verification against upstream DVC.exe


### PR DESCRIPTION
Added `expected.xml` to the file table in golden-tests.md and updated the regeneration instruction from "three files" to "four files" to reflect the XML output format added in Phase 8.